### PR TITLE
Fixed NPE issue with debug() method, when locality does not exist

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -126,7 +126,12 @@ module.exports = function(options) {
     language = language || fallbackLanguage;
     locale = language + '-' + country;
 
-    debug('locale in req: ' + util.inspect(res.locals.context.locality, debugOptions));
+    if (res.locals.context && res.locals.context.locality) {
+      debug('locale in req: ' + util.inspect(res.locals.context.locality, debugOptions));
+    }
+    else {
+      debug('locality in req: res.locals.context.locality does not exist ');
+    }
     debug('resolved locale: ' + locale);
 
     // callback after the content is loaded

--- a/lib/index.js
+++ b/lib/index.js
@@ -130,7 +130,7 @@ module.exports = function(options) {
       debug('locale in req: ' + util.inspect(res.locals.context.locality, debugOptions));
     }
     else {
-      debug('locality in req: res.locals.context.locality does not exist ');
+      debug('locality in req: res.locals.context.locality does not exist');
     }
     debug('resolved locale: ' + locale);
 


### PR DESCRIPTION
Found issue when using the module when nobody sets the locality, 'res.locals.context.locality'
